### PR TITLE
bugfix for issue #220 (In low BPM, exercise starts playing before cade…)

### DIFF
--- a/src/app/exercise/exercise.page/state/exercise-state.service.ts
+++ b/src/app/exercise/exercise.page/state/exercise-state.service.ts
@@ -267,7 +267,8 @@ export class ExerciseStateService extends BaseDestroyable implements OnDestroy {
         },
       },
       {
-        partOrTime: 100,
+        // Adding Delay between Cadence and Question, depending on BPM
+        partOrTime: (1200/this._globalSettings.bpm)*150-600,
       },
     ];
     if (this._currentQuestion.type === 'youtube') {


### PR DESCRIPTION
This pull request fixes the issue of overlapping playbacks of cadence and question in low BPM by replacing the existing delay of 500ms by a variable delay depending on BPM.

However, this delay still does not take into account the length of the cadence played. but it seems that at the moment all cadences consist of four chords, so no need at the moment.

