### PR TITLE
Support chord inversions

### DIFF
--- a/src/app/exercise/exercise.page/components/exercise-settings.page/components/included-answers/components/included-answers-multi-answer-button/included-answers-multi-answer-button.component.html
+++ b/src/app/exercise/exercise.page/components/exercise-settings.page/components/included-answers/components/included-answers-multi-answer-button/included-answers-multi-answer-button.component.html
@@ -1,3 +1,3 @@
 <app-included-answers-button [included]="isIncluded()" (click)="toggleAnswer()">
-  {{ multiAnswerCell()?.displayLabel }}
+  <span [innerHTML]="multiAnswerCell()?.displayLabel"></span>
 </app-included-answers-button>

--- a/src/app/exercise/exercise.page/components/multi-answer-button/multi-answer-button.component.html
+++ b/src/app/exercise/exercise.page/components/multi-answer-button/multi-answer-button.component.html
@@ -3,5 +3,5 @@
   [wrong]="isWrong()"
   [disabled]="!state.isAnswerEnabled()"
 >
-  {{ multiAnswerCell().displayLabel }}
+  <span [innerHTML]="multiAnswerCell().displayLabel"></span>
 </app-answer-button>

--- a/src/app/exercise/utility/music/chords/Chord/Chord.ts
+++ b/src/app/exercise/utility/music/chords/Chord/Chord.ts
@@ -31,7 +31,7 @@ const chordSymbolRegex = new RegExp(
 );
 
 export class Chord {
-  private readonly _intervals: Interval[];
+  readonly intervals: Interval[];
   readonly root: NoteType;
   readonly type: ChordType;
   readonly symbol: ChordSymbol;
@@ -67,7 +67,7 @@ export class Chord {
         this.symbol = `${this.symbol}/${this.bass}` as string as ChordSymbol;
       }
     }
-    this._intervals = this._getChordIntervals();
+    this.intervals = this._getChordIntervals();
     this.noteTypes = this._getNoteTypes();
   }
 
@@ -81,7 +81,7 @@ export class Chord {
   }
 
   private _getNoteTypes(): NoteType[] {
-    return this._intervals.map((interval) => transpose(this.root, interval));
+    return this.intervals.map((interval) => transpose(this.root, interval));
   }
 
   getBass(): Note[] {
@@ -108,7 +108,7 @@ export class Chord {
 
     // first build the chord without inversions
     const rootNote: Note = noteTypeToNote(this.root, 1);
-    let chordVoicing: Note[] = this._intervals.map((interval) =>
+    let chordVoicing: Note[] = this.intervals.map((interval) =>
       transpose(rootNote, interval),
     );
 

--- a/src/app/exercise/utility/music/chords/voiceChordProgressionWithVoiceLeading.ts
+++ b/src/app/exercise/utility/music/chords/voiceChordProgressionWithVoiceLeading.ts
@@ -124,10 +124,10 @@ export function voiceChordProgressionWithVoiceLeading(
   }
   // adding bass notes
   return chordVoicingWithoutBass.map((chordVoicing: Note[], index): Note[] => {
-    const rootNote: NoteType = chordList[index].root;
+    const bassNote: NoteType = chordList[index].bass;
     return [
       ...(options.withBass
-        ? [noteTypeToNote(rootNote, 2), noteTypeToNote(rootNote, 3)]
+        ? [noteTypeToNote(bassNote, 2), noteTypeToNote(bassNote, 3)]
         : []),
       ...chordVoicing,
     ];


### PR DESCRIPTION
![image](https://github.com/ShacharHarshuv/open-ear/assets/4821858/d3ea7ddd-24ef-4f18-a8ad-d7434ca33d34)

Support chord inversions (aka slash chords) in nested answers. 

Note the special notation used to avoid confusion between jazz extensions and classical analysis (jazz extensions are always used). (i.e. I6 is C6 and I/3 is C/E)