### PR TITLE
stop drone when leaving an exercise

### DIFF
--- a/src/app/exercise/exercise.page/state/exercise-state.service.ts
+++ b/src/app/exercise/exercise.page/state/exercise-state.service.ts
@@ -443,6 +443,7 @@ export class ExerciseStateService implements OnDestroy {
 
   ngOnDestroy(): void {
     this.stop();
+    this._dronePlayer.stopDrone();
     this._destroyed = true; // used to prevent playing of pending actions
   }
 


### PR DESCRIPTION
Hey,

Awesome job with this app @ShacharHarshuv!

I noticed in android that when I had the drone setting turned on for any of the exercises, the drone kept playing after I left the exercise or even when I left the app. I was able to reproduce this issue locally and on the web version here: https://open-ear-nine.vercel.app/home

I just added an explicit call to stopDrone in the ngOnDestroy of the state service... I tested it locally in the browser and it seemed to fix the issue, not sure about how to test it on mobile since my machine isn't really set up for it...

Let me know what you think!