### PR TITLE
In order to prevent app widgets from overlapping system buttons (namely Back, Home, and Recent), safe areas were added to several pages (see description for full details)

### DIFF
--- a/src/app/about/about.page.scss
+++ b/src/app/about/about.page.scss
@@ -1,0 +1,3 @@
+ion-content {
+  --padding-bottom: env(safe-area-inset-bottom);
+}

--- a/src/app/exercise/exercise.page/components/exercise-help/exercise-explanation/exercise-explanation.page.html
+++ b/src/app/exercise/exercise.page/components/exercise-help/exercise-explanation/exercise-explanation.page.html
@@ -1,7 +1,11 @@
 <app-modal-frame [title]="exerciseName" #modal="modal">
-  <div class="exercise-explanation__content">
-    <ng-template [appExerciseExplanationContent]="content"></ng-template>
-  </div>
+  <ion-content>
+    <div class="safe-area-wrapper">
+      <div class="exercise-explanation__content">
+        <ng-template [appExerciseExplanationContent]="content"></ng-template>
+      </div>
 
-  <ion-button expand="block" (click)="modal.close()">Got It</ion-button>
+      <ion-button expand="block" (click)="modal.close()">Got It</ion-button>
+    </div>
+  </ion-content>
 </app-modal-frame>

--- a/src/app/exercise/exercise.page/components/exercise-help/exercise-explanation/exercise-explanation.page.scss
+++ b/src/app/exercise/exercise.page/components/exercise-help/exercise-explanation/exercise-explanation.page.scss
@@ -13,3 +13,7 @@ ion-content {
     flex-direction: column;
   }
 }
+
+.safe-area-wrapper {
+  padding-bottom: env(safe-area-inset-bottom);
+}

--- a/src/app/exercise/exercise.page/exercise.page.scss
+++ b/src/app/exercise/exercise.page/exercise.page.scss
@@ -31,3 +31,7 @@
 ion-title {
   padding: 0;
 }
+
+ion-content {
+  --padding-bottom: env(safe-area-inset-bottom);
+}

--- a/src/app/home/components/exercise-summary/exercise-summary.component.scss
+++ b/src/app/home/components/exercise-summary/exercise-summary.component.scss
@@ -1,0 +1,3 @@
+ion-content {
+  --padding-bottom: env(safe-area-inset-bottom);
+}

--- a/src/app/home/home.page.scss
+++ b/src/app/home/home.page.scss
@@ -1,0 +1,3 @@
+ion-content {
+  --padding-bottom: env(safe-area-inset-bottom);
+}


### PR DESCRIPTION
    Safe areas added to:
        - src/app/about/about.page.scss
        - src/app/exercise/exercise.page/components/exercise-help/exercise-explanation/exercise-explanation.page.html
        - src/app/exercise/exercise.page/components/exercise-help/exercise-explanation/exercise-explanation.page.scss
        - src/app/exercise/exercise.page/exercise.page.scss
        - src/app/home/components/exercise-summary/exercise-summary.component.scss
        - src/app/home/home.page.scss