### PR TITLE
Feature: User Option for Setting the Drone Octave

### DIFF
--- a/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.spec.ts
+++ b/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.spec.ts
@@ -9,7 +9,7 @@ export const defaultTonalExerciseSettings: TonalExerciseSettings = {
   key: 'random',
   newKeyEvery: 0,
   drone: false,
-  droneOct: 2
+  droneOctave: 2
 };
 
 export const expectedTonalExerciseSettingsDescriptors: string[] = [
@@ -73,7 +73,7 @@ describe(useTonalExercise.name, function () {
       };
 
       const question = tonalExercise.getQuestion(
-        { ...defaultTonalExerciseSettings, key: 'C', drone: 1, droneOct: 3 },
+        { ...defaultTonalExerciseSettings, key: 'C', drone: 1, droneOctave: 3 },
         questionInC,
       );
 

--- a/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.spec.ts
+++ b/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.spec.ts
@@ -9,6 +9,7 @@ export const defaultTonalExerciseSettings: TonalExerciseSettings = {
   key: 'random',
   newKeyEvery: 0,
   drone: false,
+  droneOct: 2
 };
 
 export const expectedTonalExerciseSettingsDescriptors: string[] = [
@@ -57,6 +58,26 @@ describe(useTonalExercise.name, function () {
       );
 
       expect(question.drone).toBeDefined();
+      expect(question.drone).not.toBeNull();
+    });
+
+    it('should change the drone octave when drone octave setting is modified', () => {
+      const tonalExercise = useTonalExercise();
+      const questionInC = {
+        segments: [
+          {
+            partToPlay: 'C4' as Note,
+            rightAnswer: 'Answer 1',
+          },
+        ],
+      };
+
+      const question = tonalExercise.getQuestion(
+        { ...defaultTonalExerciseSettings, key: 'C', drone: 1, droneOct: 3 },
+        questionInC,
+      );
+
+      expect(question.drone).toBe("C3");
       expect(question.drone).not.toBeNull();
     });
 

--- a/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.spec.ts
+++ b/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.spec.ts
@@ -63,10 +63,10 @@ describe(useTonalExercise.name, function () {
 
     it('should change the drone octave when drone octave setting is modified', () => {
       const tonalExercise = useTonalExercise();
-      const questionInC = {
+      const questionInC: NotesQuestion = {
         segments: [
           {
-            partToPlay: 'C4' as Note,
+            partToPlay: "C4",
             rightAnswer: 'Answer 1',
           },
         ],
@@ -78,7 +78,6 @@ describe(useTonalExercise.name, function () {
       );
 
       expect(question.drone).toBe("C3");
-      expect(question.drone).not.toBeNull();
     });
 
     it('should not include drone when drone setting is false', () => {

--- a/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.ts
+++ b/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.ts
@@ -81,7 +81,7 @@ export type DroneOctaveSettings = {
 export const droneOctaveNumSettingDescriptor: SettingsControlDescriptor<DroneOctaveSettings> =
   {
     key: 'droneOctave',
-    info: 'Set Drone\'s octave. Recommand for people who want to hear the tonic at higher register. Eg: Drones for Key D are D1, D2, D3 ...',
+    info: 'Set Drone\'s octave. Useful if you want to hear the tonic drone at a higher register',
     descriptor: {
       controlType: 'select',
       label: 'Drone Octave',
@@ -89,31 +89,31 @@ export const droneOctaveNumSettingDescriptor: SettingsControlDescriptor<DroneOct
 
         {
           value: 1,
-          label: '1st (Eg. C1)',
+          label: '1st',
         },
         {
           value: 2,
-          label: '2nd (Eg. C2)',
+          label: '2nd',
         },
         {
           value: 3,
-          label: '3rd (Eg. C3)',
+          label: '3rd',
         },
         {
           value: 4,
-          label: '4th (Eg. C4)',
+          label: '4th',
         },
         {
           value: 5,
-          label: '5th (Eg. C5)',
+          label: '5th',
         },
         {
           value: 6,
-          label: '6th (Eg. C6)',
+          label: '6th',
         },
         {
           value: 7,
-          label: '7th (Eg. C7)',
+          label: '7th',
         },
       ],
     },
@@ -147,14 +147,14 @@ export type TonalExerciseConfig = {
   // the downside is that order is not guaranteed to be consistent between exercises, but maybe the flexibility & simplicity is worth it
   keySelection?: boolean;
   droneSelection?: boolean;
-  DroneOctaveSettings?: number;
+  droneOctaveSettings?: number;
 };
 
 export function useTonalExercise(config?: TonalExerciseConfig) {
   const fullConfig: Required<TonalExerciseConfig> = _.defaults(config, {
     keySelection: true,
     droneSelection: true,
-    DroneOctaveSettings: 2
+    droneOctaveSettings: 2
   });
   let questionCount = 0;
   let key: Key;
@@ -225,7 +225,7 @@ export function useTonalExercise(config?: TonalExerciseConfig) {
     [
       ...(fullConfig.keySelection ? keySelectionSettingsDescriptors : []),
       ...(fullConfig.droneSelection ? [droneSettingsDescriptor] : []),
-      ...(fullConfig.DroneOctaveSettings ? [droneOctaveNumSettingDescriptor] : []),
+      ...(fullConfig.droneOctaveSettings ? [droneOctaveNumSettingDescriptor] : []),
     ];
 
   return {

--- a/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.ts
+++ b/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.ts
@@ -74,14 +74,14 @@ export const droneSettingsDescriptor: SettingsControlDescriptor<DroneSettings> =
   };
 
 
-export type DroneOctSettings = {
-  droneOct: 1 | 2 | 3 | 4 | 5 | 6 | 7;
+export type DroneOctaveSettings = {
+  droneOctave: 1 | 2 | 3 | 4 | 5 | 6 | 7;
 };
 
-export const droneOctNumSettingDescriptor: SettingsControlDescriptor<DroneOctSettings> =
+export const droneOctaveNumSettingDescriptor: SettingsControlDescriptor<DroneOctaveSettings> =
   {
-    key: 'droneOct',
-    info: 'Set Drone\'s octave. Recommand for people who want hear the tonic at higher register. Eg: Drone for Key D, D1, D2, D3 ...',
+    key: 'droneOctave',
+    info: 'Set Drone\'s octave. Recommand for people who want to hear the tonic at higher register. Eg: Drones for Key D are D1, D2, D3 ...',
     descriptor: {
       controlType: 'select',
       label: 'Drone Octave',
@@ -119,7 +119,7 @@ export const droneOctNumSettingDescriptor: SettingsControlDescriptor<DroneOctSet
     },
   };
 
-export type TonalExerciseSettings = KeySelectionSettings & DroneSettings & DroneOctSettings;
+export type TonalExerciseSettings = KeySelectionSettings & DroneSettings & DroneOctaveSettings;
 
 export type TonalExerciseUtils = {
   getRangeForKeyOfC(rangeForPlaying: NotesRange): NotesRange;
@@ -147,14 +147,14 @@ export type TonalExerciseConfig = {
   // the downside is that order is not guaranteed to be consistent between exercises, but maybe the flexibility & simplicity is worth it
   keySelection?: boolean;
   droneSelection?: boolean;
-  DroneOctSettings?: number;
+  DroneOctaveSettings?: number;
 };
 
 export function useTonalExercise(config?: TonalExerciseConfig) {
   const fullConfig: Required<TonalExerciseConfig> = _.defaults(config, {
     keySelection: true,
     droneSelection: true,
-    DroneOctSettings: 2
+    DroneOctaveSettings: 2
   });
   let questionCount = 0;
   let key: Key;
@@ -218,14 +218,14 @@ export function useTonalExercise(config?: TonalExerciseConfig) {
     key: 'random',
     newKeyEvery: 10,
     drone: false,
-    droneOct: 2
+    droneOctave: 2
   };
 
   const settingsDescriptors: SettingsControlDescriptor<TonalExerciseSettings>[] =
     [
       ...(fullConfig.keySelection ? keySelectionSettingsDescriptors : []),
       ...(fullConfig.droneSelection ? [droneSettingsDescriptor] : []),
-      ...(fullConfig.DroneOctSettings ? [droneOctNumSettingDescriptor] : []),
+      ...(fullConfig.DroneOctaveSettings ? [droneOctaveNumSettingDescriptor] : []),
     ];
 
   return {
@@ -255,7 +255,7 @@ export function useTonalExercise(config?: TonalExerciseConfig) {
         key, // necessary to enforce cadence playback in case of key change
         drone: settings.drone
           ? transpose(
-              noteTypeToNote(key, settings.drone > 4 ? settings.droneOct - 1 : settings.droneOct),
+              noteTypeToNote(key, settings.drone > 4 ? settings.droneOctave - 1 : settings.droneOctave),
               scaleDegreeToChromaticDegree[settings.drone.toString()] - 1,
             )
           : null,

--- a/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.ts
+++ b/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.ts
@@ -78,7 +78,7 @@ export type DroneOctaveSettings = {
   droneOctave: 1 | 2 | 3 | 4 | 5 | 6 | 7;
 };
 
-export const droneOctaveNumSettingDescriptor: SettingsControlDescriptor<DroneOctaveSettings> =
+export const droneOctaveSettingDescriptor: SettingsControlDescriptor<DroneOctaveSettings> =
   {
     key: 'droneOctave',
     info: 'Set Drone\'s octave. Useful if you want to hear the tonic drone at a higher register',
@@ -225,7 +225,7 @@ export function useTonalExercise(config?: TonalExerciseConfig) {
     [
       ...(fullConfig.keySelection ? keySelectionSettingsDescriptors : []),
       ...(fullConfig.droneSelection ? [droneSettingsDescriptor] : []),
-      ...(fullConfig.droneOctaveSelection ? [droneOctaveNumSettingDescriptor] : []),
+      ...(fullConfig.droneOctaveSelection ? [droneOctaveSettingDescriptor] : []),
     ];
 
   return {

--- a/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.ts
+++ b/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.ts
@@ -81,39 +81,39 @@ export type DroneOctSettings = {
 export const droneOctNumSettingDescriptor: SettingsControlDescriptor<DroneOctSettings> =
   {
     key: 'droneOct',
-    info: 'Set the Octave number for Drone. (Eg: Drone for Key D, D1, D2, D3 ...)',
+    info: 'Set Drone\'s octave. Recommand for people who want hear the tonic at higher register. Eg: Drone for Key D, D1, D2, D3 ...',
     descriptor: {
       controlType: 'select',
-      label: 'Drone Octave Number',
+      label: 'Drone Octave',
       options: [
 
         {
           value: 1,
-          label: '1st Oct (Eg. C1)',
+          label: '1st (Eg. C1)',
         },
         {
           value: 2,
-          label: '2nd Oct (Eg. C2)',
+          label: '2nd (Eg. C2)',
         },
         {
           value: 3,
-          label: '3rd Oct (Eg. C3)',
+          label: '3rd (Eg. C3)',
         },
         {
           value: 4,
-          label: '4th Oct (Eg. C3)',
+          label: '4th (Eg. C4)',
         },
         {
           value: 5,
-          label: '5th Oct (Eg. C3)',
+          label: '5th (Eg. C5)',
         },
         {
           value: 6,
-          label: '6th Oct (Eg. C3)',
+          label: '6th (Eg. C6)',
         },
         {
           value: 7,
-          label: '7th Oct (Eg. C3)',
+          label: '7th (Eg. C7)',
         },
       ],
     },

--- a/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.ts
+++ b/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.ts
@@ -147,14 +147,14 @@ export type TonalExerciseConfig = {
   // the downside is that order is not guaranteed to be consistent between exercises, but maybe the flexibility & simplicity is worth it
   keySelection?: boolean;
   droneSelection?: boolean;
-  droneOctaveSettings?: number;
+  droneOctaveSelection?: boolean;
 };
 
 export function useTonalExercise(config?: TonalExerciseConfig) {
   const fullConfig: Required<TonalExerciseConfig> = _.defaults(config, {
     keySelection: true,
     droneSelection: true,
-    droneOctaveSettings: 2
+    droneOctaveSelection: true
   });
   let questionCount = 0;
   let key: Key;
@@ -225,7 +225,7 @@ export function useTonalExercise(config?: TonalExerciseConfig) {
     [
       ...(fullConfig.keySelection ? keySelectionSettingsDescriptors : []),
       ...(fullConfig.droneSelection ? [droneSettingsDescriptor] : []),
-      ...(fullConfig.droneOctaveSettings ? [droneOctaveNumSettingDescriptor] : []),
+      ...(fullConfig.droneOctaveSelection ? [droneOctaveNumSettingDescriptor] : []),
     ];
 
   return {

--- a/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.ts
+++ b/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.ts
@@ -73,7 +73,53 @@ export const droneSettingsDescriptor: SettingsControlDescriptor<DroneSettings> =
     },
   };
 
-export type TonalExerciseSettings = KeySelectionSettings & DroneSettings;
+
+export type DroneOctSettings = {
+  droneOct: 1 | 2 | 3 | 4 | 5 | 6 | 7;
+};
+
+export const droneOctNumSettingDescriptor: SettingsControlDescriptor<DroneOctSettings> =
+  {
+    key: 'droneOct',
+    info: 'Set the Octave number for Drone. (Eg: Drone for Key D, D1, D2, D3 ...)',
+    descriptor: {
+      controlType: 'select',
+      label: 'Drone Octave Number',
+      options: [
+
+        {
+          value: 1,
+          label: '1st Oct (Eg. C1)',
+        },
+        {
+          value: 2,
+          label: '2nd Oct (Eg. C2)',
+        },
+        {
+          value: 3,
+          label: '3rd Oct (Eg. C3)',
+        },
+        {
+          value: 4,
+          label: '4th Oct (Eg. C3)',
+        },
+        {
+          value: 5,
+          label: '5th Oct (Eg. C3)',
+        },
+        {
+          value: 6,
+          label: '6th Oct (Eg. C3)',
+        },
+        {
+          value: 7,
+          label: '7th Oct (Eg. C3)',
+        },
+      ],
+    },
+  };
+
+export type TonalExerciseSettings = KeySelectionSettings & DroneSettings & DroneOctSettings;
 
 export type TonalExerciseUtils = {
   getRangeForKeyOfC(rangeForPlaying: NotesRange): NotesRange;
@@ -101,12 +147,14 @@ export type TonalExerciseConfig = {
   // the downside is that order is not guaranteed to be consistent between exercises, but maybe the flexibility & simplicity is worth it
   keySelection?: boolean;
   droneSelection?: boolean;
+  DroneOctSettings?: number;
 };
 
 export function useTonalExercise(config?: TonalExerciseConfig) {
   const fullConfig: Required<TonalExerciseConfig> = _.defaults(config, {
     keySelection: true,
     droneSelection: true,
+    DroneOctSettings: 2
   });
   let questionCount = 0;
   let key: Key;
@@ -170,12 +218,14 @@ export function useTonalExercise(config?: TonalExerciseConfig) {
     key: 'random',
     newKeyEvery: 10,
     drone: false,
+    droneOct: 2
   };
 
   const settingsDescriptors: SettingsControlDescriptor<TonalExerciseSettings>[] =
     [
       ...(fullConfig.keySelection ? keySelectionSettingsDescriptors : []),
       ...(fullConfig.droneSelection ? [droneSettingsDescriptor] : []),
+      ...(fullConfig.DroneOctSettings ? [droneOctNumSettingDescriptor] : []),
     ];
 
   return {
@@ -205,7 +255,7 @@ export function useTonalExercise(config?: TonalExerciseConfig) {
         key, // necessary to enforce cadence playback in case of key change
         drone: settings.drone
           ? transpose(
-              noteTypeToNote(key, settings.drone > 4 ? 1 : 2),
+              noteTypeToNote(key, settings.drone > 4 ? settings.droneOct - 1 : settings.droneOct),
               scaleDegreeToChromaticDegree[settings.drone.toString()] - 1,
             )
           : null,

--- a/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.ts
+++ b/src/app/exercise/exercises/utility/exerciseAttributes/tonalExercise.ts
@@ -81,6 +81,7 @@ export type DroneOctaveSettings = {
 export const droneOctaveSettingDescriptor: SettingsControlDescriptor<DroneOctaveSettings> =
   {
     key: 'droneOctave',
+    show: (settings: DroneSettings) => !!settings.drone,
     info: 'Set Drone\'s octave. Useful if you want to hear the tonic drone at a higher register',
     descriptor: {
       controlType: 'select',


### PR DESCRIPTION
I had a hard time singing the drone and comparing the given tone to it because the drone is in lower register (1st, 2nd octave). So I add an option to modify its octave.   

Here is a preview of the setting menu:
<img width="1076" height="1004" alt="image" src="https://github.com/user-attachments/assets/6263232f-2ce2-4938-ba11-5d46cb3c3961" />    
Setting the Drone Octave to 3rd will make the app play C3 instead of default C2.  

Any suggestion will be appreciated!